### PR TITLE
Use 115200n8 for serial console to match what early boot (m1n1, u-boot, etc.) is using and what the Central Scrutinizer expects.

### DIFF
--- a/apple-silicon-support/modules/kernel/default.nix
+++ b/apple-silicon-support/modules/kernel/default.nix
@@ -57,7 +57,7 @@
 
     boot.kernelParams = [
       "earlycon"
-      "console=ttySAC0,1500000"
+      "console=ttySAC0,115200n8"
       "console=tty0"
       "boot.shell_on_fail"
       # Apple's SSDs are slow (~dozens of ms) at processing flush requests which


### PR DESCRIPTION
I spent a bit too much time debugging why Central Scrutinizer wasn't working immediately with NixOS, turns out it was this baud rate.  Notably it differs from what the rest of boot uses, so I think it should match the defaults for those parts.  Unfortunately Central Scrutinizer isn't configurable, so if we set everything else to 1.5M it would not work by default.